### PR TITLE
Fix usage with pydantic 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   'elasticsearch==8.11.0',
   'pydantic>=1.2',
   'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.3.8#subdirectory=crates/pyluwen',
-  'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.3',
+  'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.6',
   'pre-commit==3.5.0',
   'networkx==3.1',
   'matplotlib==3.7.4'


### PR DESCRIPTION
Bump `tt_tools_common` dependency to latest v1.4.6 (v1.4.4 or later required).

Resolves issue #17.
Fixes up #16.