### PR TITLE
Fix (#36): Use actual PCI interface IDs instead of assuming sequential numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.8 - 08/05/2025
+
+### Updated
+
+- Fixed issue where tool would fail when PCI interfaces don't start from ID 0
+- Now using actual PCI interface IDs from devices instead of assuming sequential numbering
+
 ## 1.2.7 - 07/05/2025
 
 ### Updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-topology"
-version = "1.2.7"
+version = "1.2.8"
 description = "ethernet topology configuration tool for Tenstorrent silicon"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tt_topology/tt_topology.py
+++ b/tt_topology/tt_topology.py
@@ -151,7 +151,7 @@ def run_and_flash(topo_backend: TopoBackend):
     # Reset all pci devices
     num_local_chips = len(topo_backend.devices)
     reset_obj = WHChipReset()
-    pci_interfaces = list(range(num_local_chips))
+    pci_interfaces = [dev.get_pci_interface_id() for dev in topo_backend.devices]
     print(
         CMD_LINE_COLOR.BLUE,
         f"Initiating reset on chips at pcie interface: {pci_interfaces}",
@@ -255,7 +255,6 @@ def run_and_flash(topo_backend: TopoBackend):
         CMD_LINE_COLOR.ENDC,
     )
 
-    pci_interfaces = list(range(num_local_chips))
     print(
         CMD_LINE_COLOR.BLUE,
         f"Initiating reset on chips at pcie interface: {pci_interfaces}",


### PR DESCRIPTION
## Ticket
https://github.com/tenstorrent/tt-topology/issues/36

## Problem description
`tt-topology` assumes PCIE devices are always enumerated starting from 0. This need not be the case.

## What's changed
- Use PCI interface IDs from device instead of assuming sequential numbering

