### PR TITLE
Bug fix for TG setup where initial chips are initalized noc_unsafe

### DIFF
--- a/tt_topology/tt_topology.py
+++ b/tt_topology/tt_topology.py
@@ -419,7 +419,7 @@ def main():
     local_only = not args.list
 
     try:
-        devices = detect_chips_with_callback(local_only=local_only, ignore_ethernet=True)
+        devices = detect_chips_with_callback(local_only=local_only)
     except Exception as e:
         print(
             CMD_LINE_COLOR.RED,


### PR DESCRIPTION
- ignore_eth initializes the chip as noc_unsafe, meaning noc reads come back as 0 hence returning the wrong shelf-rack on TG