### PR TITLE
chore: loosen dependency requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ classifiers = [
 dependencies = [
   'tt_tools_common>=1.4.19',
   'pyluwen>=0.7.9',
-  'black==24.3.0',
-  'elasticsearch==8.11.0',
+  'black>=24.3.0',
+  'elasticsearch>=8.11.0',
   'pydantic>=1.2',
-  'pre-commit==3.5.0',
-  'networkx==3.1',
-  'matplotlib==3.7.4',
-  'setuptools==78.1.1',
+  'pre-commit>=3.5.0',
+  'networkx>=3.1',
+  'matplotlib>=3.7.4',
+  'setuptools>=78.1.1',
 ]
 
 [project.urls]


### PR DESCRIPTION
Similar motivation to https://github.com/tenstorrent/tt-tools-common/pull/30. It is easier to package for more distros and not have conflicts when the dependency requirements are not as tight.