### PR TITLE
Exit if no supported devices are detected

### DIFF
--- a/tt_topology/tt_topology.py
+++ b/tt_topology/tt_topology.py
@@ -459,13 +459,22 @@ def main():
             supported_devices.append(dev)
         else:
             unsupported_device_names.append(board_type)
+
     # Notify the user; empty lists are falsy
     if unsupported_device_names:
         print(
             ORANGE,
-            f"TT-Topology will only run on n300/n150/GALAXY(WH 4U only) boards.\n Ignoring these devices: {', '.join(unsupported_device_names)}.",
+            f"TT-Topology will only run on n300/n150/GALAXY(WH 4U only) boards.\n",
+            f"Ignoring these devices: {', '.join(unsupported_device_names)}.",
             CMD_LINE_COLOR.ENDC,
         )
+        if not supported_devices:
+            print(
+                CMD_LINE_COLOR.RED,
+                "No devices supported by TT-Topology detected. Exiting...",
+                CMD_LINE_COLOR.ENDC,
+            )
+            sys.exit(1)
     # Proceed with only supported devices
     devices = supported_devices
 


### PR DESCRIPTION
Even though there is a printed warning, it's not clear to users when TT-Topology can't be used. Exit when there are no supported devices to prevent errors that arise from running the tool when it's not needed.

Running on a p150 before:

```
$ tt-topology  -l mesh
 Detected Chips: 1
 TT-Topology will only run on n300/n150/GALAXY(WH 4U only) boards.
 Ignoring these devices: N/A. 
 Starting flash on pcie chips to default state. 
 Sleeping for 15s ... 
 Finished flashing pcie chips to default state. 
 Initiating reset on chips at pcie interface: [] 
 Starting PCI link reset on WH devices at PCI indices:  
 Finishing PCI link reset on WH devices at PCI indices:  
 Completed reset on 0 chips 
 Detected Chips: 1
 Detecting ARC: |
 Detecting DRAM: |
 [] [14/14] ETH: |
 Post reset detected : 1 chips 
 Traceback (most recent call last):
  File "/home/palexson/tt-topology/.venv/lib/python3.10/site-packages/tt_topology/tt_topology.py", line 519, in main
    run_and_flash(topo_backend)
  File "/home/palexson/tt-topology/.venv/lib/python3.10/site-packages/tt_topology/tt_topology.py", line 198, in run_and_flash
    connection_data = topo_backend.generate_connection_map()
  File "/home/palexson/tt-topology/.venv/lib/python3.10/site-packages/tt_topology/backend.py", line 350, in generate_connection_map
    eth_board_info = self.get_local_eth_board_info(chip)
  File "/home/palexson/tt-topology/.venv/lib/python3.10/site-packages/tt_topology/backend.py", line 323, in get_local_eth_board_info
    chip.noc_read(0, eth_x, eth_y, constants.ETH_TEST_RESULT_LOCAL_TYPE, local_board_type)
AttributeError: 'NoneType' object has no attribute 'noc_read'
```

After:
```
$ tt-topology  -l mesh
 Detected Chips: 1
 TT-Topology will only run on n300/n150/GALAXY(WH 4U only) boards.
 Ignoring these devices: N/A. 
 No devices supported by TT-Topology detected. Exiting... 
```