### PR TITLE
Clean up dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tt-topology"
 version = "1.2.13"
 description = "ethernet topology configuration tool for Tenstorrent silicon"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
   { name = "Sam Bansal", email = "sbansal@tenstorrent.com" }
@@ -16,23 +16,22 @@ classifiers = [
   "Environment :: Console :: Curses",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  'tt_tools_common>=1.4.19',
-  'pyluwen>=0.7.9',
-  'black>=24.3.0',
+  'tt_tools_common==1.4.31',
+  'pyluwen==0.7.12',
   'elasticsearch>=8.11.0',
   'pydantic>=1.2',
-  'pre-commit>=3.5.0',
   'networkx>=3.1',
   'matplotlib>=3.7.4',
-  'setuptools>=78.1.1',
+]
+
+optional-dependencies.dev = [
+  'black>=24.3.0',
+  'pre-commit>=3.5.0',
 ]
 
 [project.urls]

--- a/tt_topology/tt_topology.py
+++ b/tt_topology/tt_topology.py
@@ -10,7 +10,7 @@ import sys
 import time
 import argparse
 import traceback
-import pkg_resources
+from importlib.metadata import version
 from tt_tools_common.reset_common.wh_reset import WHChipReset
 from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
 from tt_tools_common.utils_common.system_utils import (
@@ -41,7 +41,7 @@ def parse_args():
         "-v",
         "--version",
         action="version",
-        version=pkg_resources.get_distribution("tt_topology").version,
+        version=version("tt_topology"),
     )
     parser.add_argument(
         "-l",


### PR DESCRIPTION
- Require python >= 3.10. I noticed that installing tt-topology on python 3.7 already wasn't working, as pre-commit 3.5.0 isn't available. This aligns tt-topology with the other Tenstorrent tools that require 3.10 or higher.
- Strictly require the latest versions of tt-tools-common and pyluwen.
- Move black and pre-commit to optional dev dependencies.
- Move from setuptools pkg_resources to importlib.metadata for accessing version.