### PR TITLE
fix typo in test_linear

### DIFF
--- a/tt_topology/tests/test_linear.py
+++ b/tt_topology/tests/test_linear.py
@@ -7,7 +7,7 @@ import networkx as nx
 os.environ["MPLCONFIGDIR"] = os.getcwd() + "/configs/"
 import matplotlib.pyplot as plt
 
-graph: {
+graph = {
     0: [3, 4, 1],
     1: [2, 5, 0],
     2: [1, 6, 3],


### PR DESCRIPTION
There was a typo leaving "graph" undefined. This fixes https://github.com/tenstorrent/tt-topology/issues/52, but maybe we want to revisit having these tests? Can we convert them to pytest format and alter ones that depend on specific infrastructure (e.g. test_galaxy)?