### PR TITLE
Chore: Bump pyluwen and tools common version to be smi compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  'tt_tools_common==1.4.33',
-  'pyluwen==0.7.12',
+  'tt_tools_common~=1.6.0',
+  'pyluwen~=0.8.0',
   'elasticsearch>=8.11.0',
   'pydantic>=1.2',
   'networkx>=3.1',


### PR DESCRIPTION
Bump libraries to be compatible with smi pyenv
 tt_tools_common: 1.4.33 -> 1.6.0
 pyluwen: 0.7.12 -> 0.8.0