### PR TITLE
Fix SIGBUS after device reset by reordering chip re-detection

### DIFF
--- a/tt_topology/tt_topology.py
+++ b/tt_topology/tt_topology.py
@@ -165,12 +165,11 @@ def run_and_flash(topo_backend: TopoBackend):
         CMD_LINE_COLOR.ENDC,
     )
 
-    # Add new config to make sure flash happened correctly
-    topo_backend.get_eth_config_state()
-
-    # wait time to make sure devices enumerate
     # Detect all devices, including remote
     topo_backend.devices = detect_chips_with_callback()
+
+    # Add new config to make sure flash happened correctly
+    topo_backend.get_eth_config_state()
 
     print(
         CMD_LINE_COLOR.PURPLE,


### PR DESCRIPTION
get_eth_config_state() was called on stale PciChip objects whose BAR mmaps had been invalidated by the preceding full_lds_reset(). Move detect_chips_with_callback() before get_eth_config_state() so the devices have fresh mappings.